### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Localize flutter apps with DeepL AI translations"
 homepage = "https://saveoursecrets.com"
+repository = "https://github.com/saveoursecrets/arb"
 license = "MIT OR Apache-2.0"
 authors = ["saveoursecrets-developers <dev@saveoursecrets.com>"]
 default-run = "arb"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Localize flutter apps with DeepL AI translations"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/szabgab/arb"
+repository = "https://github.com/saveoursecrets/arb"
 
 [dependencies]
 serde.workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Localize flutter apps with DeepL AI translations"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/szabgab/arb"
 
 [dependencies]
 serde.workspace = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.